### PR TITLE
reordered arguments for pandoc to load user-specified before others

### DIFF
--- a/lib/pandoc-helper.coffee
+++ b/lib/pandoc-helper.coffee
@@ -152,7 +152,7 @@ getArguments = (args) ->
           res.push "--#{key}=#{v}" unless _.isEmpty v
       return res
     , []
-  args = _.union args, atom.config.get('markdown-preview-plus.pandocArguments')
+  args = _.union atom.config.get('markdown-preview-plus.pandocArguments'), args
   args = _.map args,
     (val) ->
       val = val.replace(/^(--[\w\-]+)\s(.+)$/i, "$1=$2")


### PR DESCRIPTION
If Citations is enabled, then pandoc-citeproc is loaded before specified Command Line Arguments. That causes problems with certain Pandoc filters, including pandoc-figs and pandoc-crossref  #203: 

https://github.com/tomduck/pandoc-fignos#usage

https://github.com/lierdakil/pandoc-crossref#pandoc-citeproc-and-pandoc-crossref

This pull request switches the order to have Command Line Arguments added before those added from `config.args`.  I am assuming that will not break anything. 
