### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ issue](https://github.com/atom-community/markdown-preview-plus/issues).
 We also have a more detailed description of
 [features](https://github.com/atom-community/markdown-preview-plus/blob/master/docs/features.md).
 
--   Fastly open a preview of any markdown with `ctrl-shift-m`
+-   Quickly open a preview of any markdown with `ctrl-shift-m`
 -   Math rendering with persistent macro support, toggled with
     `ctrl-shift-x`
 -   Optionally use pandoc with citation support


### PR DESCRIPTION
It isn't normally correct to use fast as an adverb

- [x] I have looked over the [contribution guide](https://github.com/atom-community/markdown-preview-plus/blob/master/CONTRIBUTING.md), which contains some crucial technical information.
