### PR TITLE
Adding menu for copying from editor pane to HTML

### DIFF
--- a/menus/markdown-preview.cson
+++ b/menus/markdown-preview.cson
@@ -22,4 +22,10 @@
     {label: 'Print\u2026', command: 'markdown-preview-plus:print'}
     {label: 'Open in new window', command: 'markdown-preview-plus:new-window'}
     {label: 'Open Dev Tools', command: 'markdown-preview-plus:open-dev-tools'}
-  ]
+  ],
+  'atom-text-editor': [
+    {
+      'label': 'Copy HTML from MD'
+      'command': 'markdown-preview-plus:copy-html'
+    }
+   ]


### PR DESCRIPTION
- [x ] I have looked over the [contribution guide](https://github.com/atom-community/markdown-preview-plus/blob/master/CONTRIBUTING.md), which contains some crucial technical information.
