### PR TITLE
fix running atom in dev mode

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,4 +1,9 @@
-if (atom.inDevMode() && require.resolve('atom-ts-transpiler')) {
+let useTranspiler = false
+try {
+  useTranspiler = atom.inDevMode() && !!require.resolve('atom-ts-transpiler')
+} catch (ex) {}
+
+if (useTranspiler) {
   console.log('Running markdown-preview-plus in dev-mode')
   module.exports = require('./src/main.ts')
 } else {


### PR DESCRIPTION
- [x] I have looked over the [contribution guide](https://github.com/atom-community/markdown-preview-plus/blob/master/CONTRIBUTING.md), which contains some crucial technical information.

If you run atom in dev mode for any folder when this packages dev dependencies aren't installed it will fail to load with the error `Error: Cannot find module 'atom-ts-transpiler'` since `require.resolve` throws an error if the module isn't installed.